### PR TITLE
Add options to remove webengine and disable numpy in flatpak build for space savings

### DIFF
--- a/org.flowkeeper.Flowkeeper.yaml
+++ b/org.flowkeeper.Flowkeeper.yaml
@@ -4,6 +4,10 @@ runtime-version: '6.8'
 sdk: org.kde.Sdk
 base: io.qt.PySide.BaseApp
 base-version: '6.8'
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
+    - BASEAPP_DISABLE_NUMPY=1
 command: run.sh
 rename-desktop-file: flowkeeper.desktop
 rename-icon: flowkeeper


### PR DESCRIPTION
This was done as per the documentation at https://github.com/flathub/io.qt.PySide.BaseApp?tab=readme-ov-file#environment-variables